### PR TITLE
fix: Windows OS detection typo

### DIFF
--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -38,7 +38,7 @@ func getNormalizedOS() string {
 		return "Android"
 	case "darwin":
 		return "MacOS"
-	case "window":
+	case "windows":
 		return "Windows"
 	case "freebsd":
 		return "FreeBSD"


### PR DESCRIPTION
I noticed while going through the code that the Windows case had a typo. It was checking for 'window' but runtime.GOOS actually returns 'windows' on Windows systems.

This meant Windows users were falling through to the default case and getting 'Other:windows' in the User-Agent header instead of 'Windows'.

Quick fix - just added the missing 's'.